### PR TITLE
fix 500 errorview if sentry/raven is not installed

### DIFF
--- a/bitpoll/base/templates/500.html
+++ b/bitpoll/base/templates/500.html
@@ -2,28 +2,40 @@
 {% load i18n %}
 {% load static %}
 {% load csp %}
-{% load raven %} {# TODO: nur wen raven/sentry aktiviert ist #}
+{% load friendly_loader %}
+{% friendly_load raven %}
+
 {% block wtitle %}{% block ptitle %}{% trans "Internal server error" %}{% endblock %}{% endblock %}
 {% block headJS %}<script src="{% static 'js/lib/raven.min.js' %}"></script>{% endblock %}
-{% sentry_public_dsn 'https' %}
+
+{% if_has_tag sentry_public_dsn %}
+        {% sentry_public_dsn 'https' %}
+{% endif_has_tag %}
+
 {% block content %}
-<script nonce="{% csp_js_nonce %}">Raven.config('{% sentry_public_dsn %}').install()</script>
+    {% if_has_tag sentry_public_dsn %}
+        {% if request.sentry %}
+            <script nonce="{% csp_js_nonce %}">Raven.config('{% sentry_public_dsn %}').install()</script>
+        {% endif %}
+    {% endif_has_tag %}
 {% url 'base_problems' as problems_url %}
     <div class="container"><section class="section">
     <div class="col-md-5">
     <h1>Internal Server Error (500)</h1>
 <p>{% blocktrans %}We're sorry, but we didn't expect this to happen. Our error reporting tool should have sent an email to us with some technical details. Please try again later. If the problem persists, see our <a href="{{ problems_url }}">problem reporting page</a>.{% endblocktrans %}</p>
-    {% if request.sentry.id %}
-        {% with request.sentry.id as errorid %}
-            <p>{% blocktrans %}We have recorded the error under the Identifier {{ errorid }}.{% endblocktrans %}</p>
-            <script nonce="{% csp_js_nonce %}">
-                Raven.showReportDialog({
-                    eventId: '{{ errorid }}',
-                    dsn: '{% sentry_public_dsn %}'
-                });{# TODO: User ausfüllen wen angemeldet? #}
-            </script>
-        {% endwith %}
-    {% endif %}
+    {% if_has_tag sentry_public_dsn %}
+        {% if request.sentry.id %}
+            {% with request.sentry.id as errorid %}
+                <p>{% blocktrans %}We have recorded the error under the Identifier {{ errorid }}.{% endblocktrans %}</p>
+                <script nonce="{% csp_js_nonce %}">
+                    Raven.showReportDialog({
+                        eventId: '{{ errorid }}',
+                        dsn: '{% sentry_public_dsn %}'
+                    });{# TODO: User ausfüllen wen angemeldet? #}
+                </script>
+            {% endwith %}
+        {% endif %}
+    {% endif_has_tag %}
     </div><div class="col-md-offset-1 col-md-5"><img src="{% static 'gfx/server-Bit.png' %}"></div>
 </section> </div>
 {% endblock %}

--- a/bitpoll/settings.py
+++ b/bitpoll/settings.py
@@ -83,6 +83,7 @@ INSTALLED_APPS = [
     'bitpoll.registration',
     'bitpoll.groups',
     'django.contrib.admin',
+    'friendlytagloader'
 ]
 
 MIDDLEWARE = [

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -4,19 +4,20 @@
 #
 #    pip-compile --output-file requirements-production.txt requirements-production.in requirements.in
 #
-django-auth-ldap==1.4.0
+django-auth-ldap==1.6.1
+django-friendly-tag-loader==1.3
 django-markdown-app==0.9.4.1
 django-pipeline==1.6.14
 django-simple-csp==0.2.dev1
 django-widget-tweaks==1.4.2
-django==2.0.4
-libsass==0.14.2           # via libsasscompiler
+django==2.0.6
+libsass==0.14.5           # via libsasscompiler
 libsasscompiler==0.1.5
 markdown==2.6.11          # via django-markdown-app
 pyasn1-modules==0.2.1     # via python-ldap
-pyasn1==0.4.2             # via pyasn1-modules, python-ldap
-python-ldap==3.0.0        # via django-auth-ldap
-pytz==2018.3
-raven==6.6.0
+pyasn1==0.4.3             # via pyasn1-modules, python-ldap
+python-ldap==3.1.0        # via django-auth-ldap
+pytz==2018.4
+raven==6.9.0
 six==1.11.0               # via libsass
 uwsgi==2.0.17

--- a/requirements.in
+++ b/requirements.in
@@ -5,3 +5,4 @@ pytz
 django-simple-csp
 libsasscompiler
 django-pipeline
+django-friendly-tag-loader

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,14 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+django-friendly-tag-loader==1.3
 django-markdown-app==0.9.4.1
 django-pipeline==1.6.14
 django-simple-csp==0.2.dev1
 django-widget-tweaks==1.4.2
-django==2.0.4
-libsass==0.14.2           # via libsasscompiler
+django==2.0.6
+libsass==0.14.5           # via libsasscompiler
 libsasscompiler==0.1.5
 markdown==2.6.11          # via django-markdown-app
-pytz==2018.3
+pytz==2018.4
 six==1.11.0               # via libsass


### PR DESCRIPTION
The 500 error view now trys to load the raven module (error reporting via Sentry) and if it is enabled show the errorID and the feedback form. If it is not installed, it just shows the generic error page.

The module django-friendly-tag-loader is used for parse type load checks.

The dependencies are updated.

fixes #27, fixes #21