### PR TITLE
Added content type for csv files

### DIFF
--- a/bitpoll/poll/views.py
+++ b/bitpoll/poll/views.py
@@ -145,7 +145,7 @@ def poll(request, poll_url: str, export: bool=False):
             max_score = max(max_score_list)
 
     if export:
-        response = HttpResponse()
+        response = HttpResponse(content_type='text/csv')
         response['Content-Disposition'] = 'attachment; filename="poll.csv"'
         writer = csv.writer(response)
         a = [choice.get_title for choice in current_poll.ordered_choices]


### PR DESCRIPTION
Currently if you try to download a csv file you get greeted by a dialog for opening the csv in your browser due to a wrong content type.

![screenshot from 2018-11-22 14-04-15](https://user-images.githubusercontent.com/4395770/48904758-af96ce80-ee5f-11e8-80c3-78a154a45267.png)

This pr fixes that by applying the correct type.

![screenshot from 2018-11-22 14-08-10](https://user-images.githubusercontent.com/4395770/48904856-14522900-ee60-11e8-967d-d43e0727c3d6.png)
