### PR TITLE
Feature calendar fixes

### DIFF
--- a/bitpoll/caldav/models.py
+++ b/bitpoll/caldav/models.py
@@ -12,3 +12,6 @@ class DavCalendar(models.Model):
     user = models.ForeignKey(BitpollUser, on_delete=models.CASCADE)
     url = EncryptedURLField()
     name = models.CharField(max_length=80)
+
+    def __str__(self):
+        return "<DavCalendar: {} {}>".format(self.user, self.name)

--- a/bitpoll/poll/views.py
+++ b/bitpoll/poll/views.py
@@ -871,7 +871,7 @@ def vote(request, poll_url, vote_id=None):
         comments.append(cur_comment)
         choice_votes.append(value)
 
-    events = get_caldav(choices, current_poll, request.user)
+    events = get_caldav(choices, current_poll, request.user, request)
 
     return TemplateResponse(request, 'poll/vote_creation.html', {
         'poll': current_poll,


### PR DESCRIPTION
Fixes if an event as more than one duration
Fixes crash on Auth error on the CalDav url

This changes the parsing of events so that errors are hopefully only sent to sentry and do not cause the vote page not to render.