### PR TITLE
Order poll choice values by weight (fixes #71)

### DIFF
--- a/bitpoll/poll/templates/poll/choicevalue.html
+++ b/bitpoll/poll/templates/poll/choicevalue.html
@@ -47,7 +47,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% for choiceval in poll.choicevalue_set.all %}
+                    {% for choiceval in choice_values %}
                         <tr class="choice vote {% if choiceval.deleted %}deleted{% endif %}">
                             <td class="author choice">{{ choiceval.title }}</td>
                             <td class="vote-choice text-center">

--- a/bitpoll/poll/views.py
+++ b/bitpoll/poll/views.py
@@ -931,7 +931,7 @@ def vote(request, poll_url, vote_id=None):
         'choices_matrix': zip(matrix, choices, comments, choice_votes, events),
         'choices': current_poll.choice_set.all(),
         'choices_matrix_len': len(choices),
-        'values': current_poll.choicevalue_set.filter(deleted=False).all().order_by('-weight', 'title'),
+        'values': current_poll.choicevalue_set.filter(deleted=False).order_by('-weight', 'title'),
         'page': 'Vote',
         'current_vote': current_vote,
         'timezone_warning': (request.user.is_authenticated and

--- a/bitpoll/poll/views.py
+++ b/bitpoll/poll/views.py
@@ -931,7 +931,7 @@ def vote(request, poll_url, vote_id=None):
         'choices_matrix': zip(matrix, choices, comments, choice_votes, events),
         'choices': current_poll.choice_set.all(),
         'choices_matrix_len': len(choices),
-        'values': current_poll.choicevalue_set.filter(deleted=False).all(),
+        'values': current_poll.choicevalue_set.filter(deleted=False).all().order_by('-weight', 'title'),
         'page': 'Vote',
         'current_vote': current_vote,
         'timezone_warning': (request.user.is_authenticated and

--- a/bitpoll/poll/views.py
+++ b/bitpoll/poll/views.py
@@ -688,7 +688,7 @@ def edit_choicevalues(request, poll_url):
         'poll': current_poll,
         'form': form,
         'choiceval_select': choiceval_select,
-        'choice_values': ChoiceValue.objects.filter(poll=current_poll)
+        'choice_values': current_poll.choicevalue_set.order_by('-weight', 'title')
     })
 
 
@@ -727,6 +727,7 @@ def edit_choicevalues_create(request, poll_url):
             'poll': current_poll,
             'form': form,
             'choiceval_select': choiceval_select,
+            'choice_values': current_poll.choicevalue_set.order_by('-weight', 'title')
         })
     return redirect('poll_editchoicevalues', current_poll.url)
 


### PR DESCRIPTION
Fixes #71 using [order_by](https://docs.djangoproject.com/en/3.1/ref/models/querysets/#order-by).

Previously choices were sorted unintuitively by position in the database.
Poll choice values will now be sorted primarily by descending weight and secondarily by title.
~~Note that this change only affects the voting view and not the choice editor.~~
Values are also sorted in the choice editor.