### PR TITLE
Fix capitalization, change strings

### DIFF
--- a/bitpoll/base/views.py
+++ b/bitpoll/base/views.py
@@ -56,8 +56,7 @@ def index(request):
             ChoiceValue(title="yes", icon="check", color="90db46", weight=1, poll=current_poll).save()
             ChoiceValue(title="no", icon="ban", color="c43131", weight=0, poll=current_poll).save()
             ChoiceValue(title="maybe", icon="question", color="ffe800", weight=0.5, poll=current_poll).save()
-            ChoiceValue(title="Only if absolutely necessary", icon="thumbs-down", color="B0E", weight=0.25,
-                        poll=current_poll).save()
+            ChoiceValue(title="rather not", icon="thumbs-down", color="B0E", weight=0.25, poll=current_poll).save()
 
             if current_poll.type == 'universal':  # TODO: heir könnte auch auf die algemeine edit url weitergeleitet werden
                 return redirect('poll_editUniversalChoice', current_poll.url)

--- a/bitpoll/poll/templates/poll/poll_header.html
+++ b/bitpoll/poll/templates/poll/poll_header.html
@@ -51,15 +51,15 @@
             {% endif %}
             {% if poll.anonymous_allowed %}
                 <li title="{% trans 'Anonymous voting allowed' %}"><i class="fa fa-check"></i>
-                    <span class="content">{% trans 'anonymous voting' %}</span></li>
+                    <span class="content">{% trans 'Anonymous voting' %}</span></li>
             {% endif %}
             {% if poll.require_invitation %}
                 <li title="{% trans 'Invitation required' %}"><i class="fa fa-check"></i>
-                    <span class="content">{% trans 'invitation required' %}</span></li>
+                    <span class="content">{% trans 'Invitation required' %}</span></li>
             {% endif %}
             {% if poll.require_login %}
                 <li title="{% trans 'Login required' %}"><i class="fa fa-check"></i>
-                    <span class="content">{% trans 'login required' %}</span></li>
+                    <span class="content">{% trans 'Login required' %}</span></li>
             {% endif %}
                 {% if poll.vote_all %}
                     <li title="{% trans 'Empty choices forbidden' %}"><i class="fa fa-ban"></i>

--- a/bitpoll/poll/templates/poll/settings.html
+++ b/bitpoll/poll/templates/poll/settings.html
@@ -91,46 +91,46 @@
 
 
         <div class="col-md-5 col-md-offset-1">
-          <label>{% trans 'additional Settings' %}</label>
+          <label>{% trans 'Additional Settings' %}</label>
             <div class="checkbox">
                 <input type="checkbox" id="allow_comments" name="{{ form.allow_comments.name }}" {% if form.allow_comments.value %} checked {% endif %}>
-                <label for="allow_comments">{% trans 'allow comments' %}</label>
+                <label for="allow_comments">{% trans 'Allow comments' %}</label>
             </div>
             <div class="checkbox">
                 <input type="checkbox" id="anonymous_allowed" name="{{ form.anonymous_allowed.name }}" {% if form.anonymous_allowed.value %} checked {% endif %}>
-                <label for="anonymous_allowed">{% trans 'allow anonymous votes' %}</label>
+                <label for="anonymous_allowed">{% trans 'Allow anonymous votes' %}</label>
             </div>
             <div class="checkbox">
                 <input type="checkbox" id="require_login" name="{{ form.require_login.name }}" {% if form.require_login.value %} checked {% endif %}>
-                <label for="require_login">{% trans 'login required' %}</label>
+                <label for="require_login">{% trans 'Login required' %}</label>
             </div>
             <div class="checkbox">
                 <input type="checkbox" id="require_invitation" name="{{ form.require_invitation.name }}" {% if form.require_invitation.value %} checked {% endif %}>
-                <label for="require_invitation">{% trans 'invitation required to vote' %}</label>
+                <label for="require_invitation">{% trans 'Invitation required to vote' %}</label>
             </div>
             <div class="checkbox">
                 <input type="checkbox" id="public_listening" name="{{ form.public_listening.name }}" {% if form.public_listening.value %} checked {% endif %}>
-                <label for="public_listening">{% trans 'show in public poll list' %}</label>
+                <label for="public_listening">{% trans 'Show in public poll list' %}</label>
             </div>
             <div class="checkbox">
                 <input type="checkbox" id="allow_unauthenticated_vote_changes" name="{{ form.allow_unauthenticated_vote_changes.name }}" {% if form.allow_unauthenticated_vote_changes.value %} checked {% endif %}>
-                <label for="allow_unauthenticated_vote_changes">{% trans 'allow unauthenticated vote changes' %}</label>
+                <label for="allow_unauthenticated_vote_changes">{% trans 'Allow unauthenticated vote changes' %}</label>
             </div>
             <div class="checkbox">
                 <input type="checkbox" id="one_vote_per_user" name="{{ form.one_vote_per_user.name }}" {% if form.one_vote_per_user.value %} checked {% endif %}>
-                <label for="one_vote_per_user">{% trans 'one vote per user' %}</label>
+                <label for="one_vote_per_user">{% trans 'One vote per user' %}</label>
             </div>
             <div class="checkbox">
                 <input type="checkbox" id="show_invitations" name="{{ form.show_invitations.name }}" {% if form.show_invitations.value %} checked {% endif %}>
-                <label for="show_invitations">{% trans 'show invitations as empty votes' %}</label>
+                <label for="show_invitations">{% trans 'Show invitations as empty votes' %}</label>
             </div>
             <div class="checkbox">
                 <input type="checkbox" id="vote_all" name="{{ form.vote_all.name }}" {% if form.vote_all.value %} checked {% endif %}>
-                <label for="vote_all">{% trans 'forbid empty choices' %}</label>
+                <label for="vote_all">{% trans 'Forbid empty choices' %}</label>
             </div>
             <div class="checkbox">
                 <input type="checkbox" id="vote_hide_participants" name="{{ form.hide_participants.name }}" {% if form.hide_participants.value %} checked {% endif %}>
-                <label for="vote_hide_participants">{% trans 'hide participants' %}</label>
+                <label for="vote_hide_participants">{% trans 'Hide participants' %}</label>
             </div>
             <div class="">
                 Sort results by:
@@ -182,7 +182,7 @@
                 If you set this to "Nobody", then anyone may claim exclusive ownership. Most restrictive settings above are useless if you do not claim ownership of this poll.
                 {% endblocktrans %}
             </div>
-            <label>{% trans 'Very advanced stuff' %}</label><br>
+            <label>{% trans 'Advanced Options' %}</label><br>
             <a href="{% url 'poll_editchoicevalues' poll.url %}">{% trans 'Edit possible answer values' %}</a><br>
             <a href="{% url 'invitations' poll.url %}">{% trans 'Manage invitations' %}</a><br>
             <a href="{% url 'poll_copy' poll.url %}">{% trans 'Copy poll' %}</a><br>

--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -337,34 +337,34 @@ msgstr "Beschreibung"
 
 #: bitpoll/base/templates/base/index.html:158
 #: bitpoll/poll/templates/poll/settings.html:101
-msgid "allow anonymous votes"
-msgstr "erlaube anonymes Abstimmen"
+msgid "Allow anonymous votes"
+msgstr "Erlaube anonymes Abstimmen"
 
 #: bitpoll/base/templates/base/index.html:162
 #: bitpoll/poll/templates/poll/poll_header.html:62
 #: bitpoll/poll/templates/poll/settings.html:105
-msgid "login required"
+msgid "Login required"
 msgstr "Login erforderlich"
 
 #: bitpoll/base/templates/base/index.html:166
 #: bitpoll/poll/templates/poll/settings.html:109
-msgid "invitation required to vote"
+msgid "Invitation required to vote"
 msgstr "Einladung zur Abstimmung erforderlich"
 
 #: bitpoll/base/templates/base/index.html:170
 #: bitpoll/poll/templates/poll/settings.html:117
-msgid "allow unauthenticated vote changes"
-msgstr "erlaube unangemeldete Änderungen an Stimmen"
+msgid "Allow unauthenticated vote changes"
+msgstr "Erlaube unangemeldete Änderungen an Stimmen"
 
 #: bitpoll/base/templates/base/index.html:174
 #: bitpoll/poll/templates/poll/settings.html:121
-msgid "one vote per user"
-msgstr "eine Stimme pro Benutzer"
+msgid "One vote per user"
+msgstr "Eine Stimme pro Benutzer"
 
 #: bitpoll/base/templates/base/index.html:178
 #: bitpoll/poll/templates/poll/settings.html:129
-msgid "forbid empty choices"
-msgstr "verbiete leere Wahlmöglichkeiten"
+msgid "Forbid empty choices"
+msgstr "Verbiete leere Wahlmöglichkeiten"
 
 #: bitpoll/base/templates/base/index.html:185
 msgid "More options"
@@ -1457,15 +1457,15 @@ msgid "Anonymous voting allowed"
 msgstr "Anonymes Abstimmen erlaubt"
 
 #: bitpoll/poll/templates/poll/poll_header.html:54
-msgid "anonymous voting"
-msgstr "anonym abstimmen"
+msgid "Anonymous voting"
+msgstr "Anonym abstimmen"
 
 #: bitpoll/poll/templates/poll/poll_header.html:57
 msgid "Invitation required"
 msgstr "Einladung erforderlich"
 
 #: bitpoll/poll/templates/poll/poll_header.html:58
-msgid "invitation required"
+msgid "Invitation required"
 msgstr "Einladung erforderlich"
 
 #: bitpoll/poll/templates/poll/poll_header.html:61
@@ -1475,7 +1475,7 @@ msgstr "Login erforderlich"
 #: bitpoll/poll/templates/poll/poll_header.html:65
 #: bitpoll/poll/templates/poll/poll_header.html:66
 msgid "Empty choices forbidden"
-msgstr "leere Wahlmöglichkeiten verboten"
+msgstr "Leere Wahlmöglichkeiten verboten"
 
 #: bitpoll/poll/templates/poll/poll_header.html:79
 msgid "Overview"
@@ -1517,23 +1517,23 @@ msgid "Save changes"
 msgstr "Speichere Änderungen"
 
 #: bitpoll/poll/templates/poll/settings.html:94
-msgid "additional Settings"
-msgstr "zusätzliche Einstellungen"
+msgid "Additional Settings"
+msgstr "Zusätzliche Einstellungen"
 
 #: bitpoll/poll/templates/poll/settings.html:97
-msgid "allow comments"
+msgid "Allow comments"
 msgstr "Kommentare erlaubt"
 
 #: bitpoll/poll/templates/poll/settings.html:113
-msgid "show in public poll list"
-msgstr "in öffentlicher Umfrageliste anzeigen"
+msgid "Show in public poll list"
+msgstr "In öffentlicher Umfrageliste anzeigen"
 
 #: bitpoll/poll/templates/poll/settings.html:125
-msgid "show invitations as empty votes"
-msgstr "zeige Einladungen als leere Stimmen an"
+msgid "Show invitations as empty votes"
+msgstr "Zeige Einladungen als leere Stimmen an"
 
 #: bitpoll/poll/templates/poll/settings.html:133
-msgid "hide participants"
+msgid "Hide participants"
 msgstr "Teilnehmerliste verbergen"
 
 #: bitpoll/poll/templates/poll/settings.html:142
@@ -1566,8 +1566,8 @@ msgstr ""
 "Umfrage in Besitz genommen hast."
 
 #: bitpoll/poll/templates/poll/settings.html:185
-msgid "Very advanced stuff"
-msgstr "Sehr fortgeschrittene Einstellungen"
+msgid "Advanced Options"
+msgstr "Fortgeschrittene Optionen"
 
 #: bitpoll/poll/templates/poll/settings.html:186
 msgid "Edit possible answer values"

--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -300,34 +300,34 @@ msgstr "Description"
 
 #: bitpoll/base/templates/base/index.html:158
 #: bitpoll/poll/templates/poll/settings.html:101
-msgid "allow anonymous votes"
-msgstr "allow anonymous votes"
+msgid "Allow anonymous votes"
+msgstr "Allow anonymous votes"
 
 #: bitpoll/base/templates/base/index.html:162
 #: bitpoll/poll/templates/poll/poll_header.html:62
 #: bitpoll/poll/templates/poll/settings.html:105
-msgid "login required"
-msgstr "login required"
+msgid "Login required"
+msgstr "Login required"
 
 #: bitpoll/base/templates/base/index.html:166
 #: bitpoll/poll/templates/poll/settings.html:109
-msgid "invitation required to vote"
-msgstr "invitation required to vote"
+msgid "Invitation required to vote"
+msgstr "Invitation required to vote"
 
 #: bitpoll/base/templates/base/index.html:170
 #: bitpoll/poll/templates/poll/settings.html:117
-msgid "allow unauthenticated vote changes"
-msgstr ""
+msgid "Allow unauthenticated vote changes"
+msgstr "Allow unauthenticated vote changes"
 
 #: bitpoll/base/templates/base/index.html:174
 #: bitpoll/poll/templates/poll/settings.html:121
-msgid "one vote per user"
-msgstr "one vote per user"
+msgid "One vote per user"
+msgstr "One vote per user"
 
 #: bitpoll/base/templates/base/index.html:178
 #: bitpoll/poll/templates/poll/settings.html:129
-msgid "forbid empty choices"
-msgstr "forbid empty choices"
+msgid "Forbid empty choices"
+msgstr "Forbid empty choices"
 
 #: bitpoll/base/templates/base/index.html:185
 msgid "More options"
@@ -1395,16 +1395,16 @@ msgid "Anonymous voting allowed"
 msgstr "Anonymous voting allowed"
 
 #: bitpoll/poll/templates/poll/poll_header.html:54
-msgid "anonymous voting"
-msgstr "anonymous voting"
+msgid "Anonymous voting"
+msgstr "Anonymous voting"
 
 #: bitpoll/poll/templates/poll/poll_header.html:57
 msgid "Invitation required"
 msgstr "Invitation required"
 
 #: bitpoll/poll/templates/poll/poll_header.html:58
-msgid "invitation required"
-msgstr "invitation required"
+msgid "Invitation required"
+msgstr "Invitation required"
 
 #: bitpoll/poll/templates/poll/poll_header.html:61
 msgid "Login required"
@@ -1457,24 +1457,24 @@ msgid "Save changes"
 msgstr "Save changes"
 
 #: bitpoll/poll/templates/poll/settings.html:94
-msgid "additional Settings"
-msgstr "additional Settings"
+msgid "Additional Settings"
+msgstr "Additional Settings"
 
 #: bitpoll/poll/templates/poll/settings.html:97
-msgid "allow comments"
-msgstr "allow comments"
+msgid "Allow comments"
+msgstr "Allow comments"
 
 #: bitpoll/poll/templates/poll/settings.html:113
-msgid "show in public poll list"
-msgstr "show in public poll list"
+msgid "Show in public poll list"
+msgstr "Show in public poll list"
 
 #: bitpoll/poll/templates/poll/settings.html:125
-msgid "show invitations as empty votes"
-msgstr "show invitations as empty votes"
+msgid "Show invitations as empty votes"
+msgstr "Show invitations as empty votes"
 
 #: bitpoll/poll/templates/poll/settings.html:133
-msgid "hide participants"
-msgstr ""
+msgid "Hide participants"
+msgstr "Hide participants"
 
 #: bitpoll/poll/templates/poll/settings.html:142
 msgid ""
@@ -1507,8 +1507,8 @@ msgstr ""
 "                "
 
 #: bitpoll/poll/templates/poll/settings.html:185
-msgid "Very advanced stuff"
-msgstr "Very advanced stuff"
+msgid "Advanced Options"
+msgstr "Advanced Options"
 
 #: bitpoll/poll/templates/poll/settings.html:186
 msgid "Edit possible answer values"


### PR DESCRIPTION
Fixes #73.

Changes:
- "Only if absolutely necessary" => "rather not" _(this option won the internal poll)_
- Fix capitalization
- "Very advanced stuff" => "Advanced Options"
- "Sehr fortgeschrittene Einstellungen" => "Fortgeschrittene Optionen"

