### PR TITLE
Added copyright info

### DIFF
--- a/locale/it_IT/LC_MESSAGES/django.po
+++ b/locale/it_IT/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
-# SOME DESCRIPTIVE TITLE.
+# ITALIAN TRANSLATION
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Fabio Lovato <fabiol@mailbox.org>, 2024.
 #
 msgid ""
 msgstr ""


### PR DESCRIPTION
Sorry for this little PR, but I have forgot the copyright info about the italian translation.

Do you have plan to release a new docker image soon? So I can dockerize BitPoll in italian language :-)
Otherwise I should anticipate these changes in the current image I have dockerized.