### PR TITLE
registration: Fix missing reverse for 'home'

### DIFF
--- a/bitpoll/registration/views.py
+++ b/bitpoll/registration/views.py
@@ -47,7 +47,7 @@ def request_successful(request, email):
 
 def create_account(request, info_token):
     if request.user.is_authenticated:
-        return redirect('home')
+        return redirect('index')
     try:
         info = signing.loads(info_token, max_age=TOKEN_MAX_AGE)
     except signing.SignatureExpired:
@@ -82,7 +82,7 @@ def create_account(request, info_token):
             user.backend = 'django.contrib.auth.backends.ModelBackend'
 
             login(request, user)
-            return redirect('home')
+            return redirect('index')
     else:
         form = SetPasswordForm(None)
 


### PR DESCRIPTION
URL path "home" was removed in commit d61c823 in favor of path "index". But it was forgotten to adjust the references. This commit makes up for this.

Fixes #160