### PR TITLE
Add configurable privacy policy url

### DIFF
--- a/bitpoll/base/views.py
+++ b/bitpoll/base/views.py
@@ -22,7 +22,7 @@ from bitpoll.base.forms import BitpollUserSettingsForm
 from pytz import all_timezones
 
 from bitpoll.registration.forms import RegisterForm
-from bitpoll.settings import IMPRINT_URL
+from bitpoll.settings import IMPRINT_URL, PRIVACY_URL
 from django.core import signing
 from django.conf import settings
 
@@ -161,7 +161,10 @@ def problems(request):
 
 
 def privacy(request):
-    return TemplateResponse(request, 'base/privacy.html')
+    if PRIVACY_URL:
+        return redirect(PRIVACY_URL)
+    else:
+        return TemplateResponse(request, 'base/privacy.html')
 
 
 @login_required

--- a/bitpoll/settings.py
+++ b/bitpoll/settings.py
@@ -52,6 +52,7 @@ TEMPLATE_ALLOWABLE_SETTINGS_VALUES = [
     'HOME_URL_NAME',
     'IMPRINT_TEXT',
     'IMPRINT_URL',
+    'PRIVACY_URL',
     'TIME_ZONE',
     'REGISTER_ENABLED',
     'MAIL_SIGNATURE',
@@ -325,6 +326,9 @@ IMPRINT_TEXT = """
 <h1>Impressum</h1>
 <p>Text goes here</p>
 """
+
+## if the PRIVACY_URL is not empty use it as an link to the privacy policy, else use bitpoll/base/templates/base/privacy.html
+PRIVACY_URL = ""
 
 LOCALE_PATHS = (os.path.join(ROOT_DIR, 'locale'), )
 

--- a/bitpoll/settings_local.sample.py
+++ b/bitpoll/settings_local.sample.py
@@ -79,6 +79,9 @@ PIPELINE_LOCAL = {}
 #<p>Text goes here</p>
 #"""
 
+## if the PRIVACY_URL is not empty use it as an link to the privacy policy, else use bitpoll/base/templates/base/privacy.html
+#PRIVACY_URL = ""
+
 #LOCALE_PATHS = (os.path.join(ROOT_DIR, 'locale'), )
 #LANGUAGES = (
 #    ('de', 'Deutsch'),


### PR DESCRIPTION
This commit allows to set a separate privacy policy url through PRIVACY_URL, just like IMPRINT_URL. If PRIVACY_URL is set the requests to `/privacy` will be redirected to that url.

Closes #162